### PR TITLE
Fix: Exclude node_modules and backend from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+exclude:
+  - node_modules/
+  - backend/


### PR DESCRIPTION
Adds a _config.yml file with rules to exclude the `node_modules/` and `backend/` directories. This prevents Jekyll from processing unnecessary files from these directories, cleaning up the build process and ensuring only relevant content is included in the site.